### PR TITLE
Added parameter for display

### DIFF
--- a/source/ouibounce.js
+++ b/source/ouibounce.js
@@ -11,7 +11,7 @@ function ouibounce(el, custom_config) {
     cookieDomain = config.cookieDomain ? ';domain=' + config.cookieDomain : '',
     cookieName   = config.cookieName ? config.cookieName : 'viewedOuibounceModal',
     sitewide     = config.sitewide === true ? ';path=/' : '',
-    displayType  = config.displayType ? config.displayType : 'block',
+    displayClass = config.displayClass ? config.displayClass : 'ouibounce-display',
     _delayTimer  = null,
     _html        = document.documentElement;
 
@@ -85,8 +85,8 @@ function ouibounce(el, custom_config) {
   function fire() {
     if (isDisabled()) { return; }
 
-    if (el) { el.style.display = displayType; }
-
+    if (el) { el.className = el.className + ' ' + displayClass; }
+    
     callback();
     disable();
   }

--- a/source/ouibounce.js
+++ b/source/ouibounce.js
@@ -11,6 +11,7 @@ function ouibounce(el, custom_config) {
     cookieDomain = config.cookieDomain ? ';domain=' + config.cookieDomain : '',
     cookieName   = config.cookieName ? config.cookieName : 'viewedOuibounceModal',
     sitewide     = config.sitewide === true ? ';path=/' : '',
+    displayType  = config.displayType ? config.displayType : 'block',
     _delayTimer  = null,
     _html        = document.documentElement;
 
@@ -84,7 +85,7 @@ function ouibounce(el, custom_config) {
   function fire() {
     if (isDisabled()) { return; }
 
-    if (el) { el.style.display = 'block'; }
+    if (el) { el.style.display = displayType; }
 
     callback();
     disable();


### PR DESCRIPTION
'displayType' is 'block' by default, emulating the usual CSS display property of the base version.

You can also set it to 'flex' if you want to restyle the popup.

When setting it to 'flex' you can use the following CSS (in addition to the existing CSS) to make the popup responsive:

``` css
#ouibounce-modal {
    justify-content: center;
    align-items: center;
    align-content: center;
}
```

**Remove** these styles:

``` css
#ouibounce-modal .modal {
    position: absolute;
    margin: auto;
    top: 0;
    right: 0;
    bottom: 0;
    left: 0;
}
```
